### PR TITLE
Fix/sd in freeze

### DIFF
--- a/include/Screen.h
+++ b/include/Screen.h
@@ -50,7 +50,7 @@ private:
     int                         m_tx;
     int                         m_rx;
     unsigned long               m_lastDrawTime;
-    const int                   m_waitTimeUs = 100000; // Needed for functioning, can still be optimized
+    const int                   m_waitTimeUs = 500000; // Needed for functioning, can still be optimized
 
 };
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,5 +14,5 @@ board = lolin_d32_pro
 framework = arduino
 
 ; If Platformio gives a upload error, please specify this for your respective COM port
-upload_port = /dev/ttyUSB0
+upload_port = COM7
 upload_speed = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,5 +14,5 @@ board = lolin_d32_pro
 framework = arduino
 
 ; If Platformio gives a upload error, please specify this for your respective COM port
-upload_port = COM7
+upload_port = /dev/ttyUSB0
 upload_speed = 115200


### PR DESCRIPTION
Apparently fixes bug where screen freezes at 'SD in'. works 10/10 times so far, while powered only via battery.