### PR TITLE
Add DEMO_INPUT_DEVICE build flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
-[env:lolin_d32_pro]
+[env]
 platform = espressif32
 board = lolin_d32_pro
 framework = arduino
@@ -16,3 +16,7 @@ framework = arduino
 ; If Platformio gives a upload error, please specify this for your respective COM port
 upload_port = /dev/ttyUSB0
 upload_speed = 230400
+
+# Demo build environment that enables demo purposes for the input device.
+[env:demo]
+build_flags = -D DEMO_INPUT_DEVICE

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,6 +87,9 @@ void sendGaitMessage(std::string name)
     gaitInstructionMessage.gait_name = name.c_str();
     gait_instruction_publisher.publish(&gaitInstructionMessage);
     gait_message_send = true;
+#ifdef DEMO_INPUT_DEVICE
+    received_gait_instruction_response = true;
+#endif
   }
 }
 


### PR DESCRIPTION
## Description
This PR introduces a demo mode for the input device that does not wait for the result of the gait instruction. It immediately sets the response to received after the message has been sent. This mode can be enabled by enabling `DEMO_INPUT_DEVICE` using

    pio run -e demo

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
* Add `DEMO_INPUT_DEVICE` env variable
* Do not wait for gait instruction result after message has been sent when `DEMO_INPUT_DEVICE` has been enabled
<!-- Please don't forget to request for reviews -->
