### PR TITLE
Fix: add id to instruction

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,6 +180,7 @@ void setup()
   nh.subscribe(gait_instruction_result_subscriber);
 
   alive_msg.id = "crutch";
+  gait_instruction_msg.id = alive_msg.id;
 
   state_machine.construct();
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
In my last PR #57 I forgot to set the `id` of the `GaitInstruction` message. That is set now too :+1:

## Changes
* Set instruction id

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
