### PR TITLE
Fix/pm 499 match alive frequency with diagnostics

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,8 +60,8 @@ Adafruit_DRV2605 driver;
 const uint8_t EFFECT = 14;
 
 // Select the alive publisher frequency:  20 (Hz) / _ALIVE_FREQUENCY_PUBLISHER_FLAG
-uint8_t _ALIVE_FREQUENCY_PUBLISHER_FLAG = 4;
-uint8_t _CURRENT_FLAG_VALUE = 0;
+const uint8_t ALIVE_FREQUENCY_PUBLISHER_FLAG = 4;
+uint8_t current_flag_value = 0;
 
 // Create ros nodehandle with publishers
 #ifdef USE_WIRELESS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,12 +290,12 @@ void loop()
   }
 
   // Average loop frequency is around 20hz / _ALIVE_FREQUENCY_PUBLISHER_FLAG.
-  if (_CURRENT_FLAG_VALUE == _ALIVE_FREQUENCY_PUBLISHER_FLAG)
+  if (current_flag_value == ALIVE_FREQUENCY_PUBLISHER_FLAG)
   {
     sendAliveMessage();
-    _CURRENT_FLAG_VALUE = 0;
+    current_flag_value = 0;
   }
-  _CURRENT_FLAG_VALUE++;
+  current_flag_value++;
 
   nh.spinOnce();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,8 +60,8 @@ Adafruit_DRV2605 driver;
 const uint8_t EFFECT = 14;
 
 // Select the alive publisher frequency:  20 (Hz) / _ALIVE_FREQUENCY_PUBLISHER_FLAG
-uint8_t _ALIVE_FREQUENCY_PUBLISHER_FLAG = 4
-uint8_t _CURRENT_FLAG_VALUE = 0
+uint8_t _ALIVE_FREQUENCY_PUBLISHER_FLAG = 4;
+uint8_t _CURRENT_FLAG_VALUE = 0;
 
 // Create ros nodehandle with publishers
 #ifdef USE_WIRELESS

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,10 @@ Adafruit_DRV2605 driver;
 // Select the desired effect, for now test effect "Buzz 100%"
 const uint8_t EFFECT = 14;
 
+// Select the alive publisher frequency:  20 (Hz) / _ALIVE_FREQUENCY_PUBLISHER_FLAG
+uint8_t _ALIVE_FREQUENCY_PUBLISHER_FLAG = 4
+uint8_t _CURRENT_FLAG_VALUE = 0
+
 // Create ros nodehandle with publishers
 #ifdef USE_WIRELESS
 ros::NodeHandle_<WiFiHardware> nh;
@@ -285,8 +289,13 @@ void loop()
     }
   }
 
-  // Average loop frequency is around 20hz.
-  sendAliveMessage();
+  // Average loop frequency is around 20hz / _ALIVE_FREQUENCY_PUBLISHER_FLAG.
+  if (_CURRENT_FLAG_VALUE == _ALIVE_FREQUENCY_PUBLISHER_FLAG)
+  {
+    sendAliveMessage();
+    _CURRENT_FLAG_VALUE = 0;
+  }
+  _CURRENT_FLAG_VALUE++;
 
   nh.spinOnce();
 }


### PR DESCRIPTION
Closes PM-499

## Description
Changes the update frequency of the input device crutch alive topic to match the frequency given in the march rqt input device. It seems redundant to have such a high frequency and 5 Hz will be more then sufficient (as it is for the rqt input device). The update loop frequency will remain unchanged but online the _alive_ topic will publish with less of 1/4 times the update frequency

## Changes
* Downscale the update frequency of the _alive_ topic of the crutch input device.