### PR TITLE
fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,10 +59,6 @@ Adafruit_DRV2605 driver;
 // Select the desired effect, for now test effect "Buzz 100%"
 const uint8_t EFFECT = 14;
 
-// Select the alive publisher frequency:  20 (Hz) / _ALIVE_FREQUENCY_PUBLISHER_FLAG
-const uint8_t ALIVE_FREQUENCY_PUBLISHER_FLAG = 4;
-uint8_t current_flag_value = 0;
-
 // Create ros nodehandle with publishers
 #ifdef USE_WIRELESS
 ros::NodeHandle_<WiFiHardware> nh;
@@ -289,13 +285,7 @@ void loop()
     }
   }
 
-  // Average loop frequency is around 20hz / _ALIVE_FREQUENCY_PUBLISHER_FLAG.
-  if (current_flag_value == ALIVE_FREQUENCY_PUBLISHER_FLAG)
-  {
-    sendAliveMessage();
-    current_flag_value = 0;
-  }
-  current_flag_value++;
+  sendAliveMessage();
 
   nh.spinOnce();
 }


### PR DESCRIPTION
## Description
Today at the software test we tested the input device with the new divided frequency alive publisher from [PM-499](https://jira.projectmarch.nl/browse/PM-499). Unfortunately when using it multiple times the input device would lose connection when a gait is selected and activated. This is probably because the alive topic does not publish when a gait is selected in the loop. I will therefore look for another solution and revert the changes to not delay or influence the upcoming training on Friday.

## Changes
* Removed the alive frequency divider