### PR TITLE
Add header timestamp on messages

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,6 +91,7 @@ void sendGaitMessage(const std::string& name)
   if (!name.empty() && !gait_message_send)
   {
     is_transitioning = false;
+    gait_instruction_msg.header.stamp = nh.now();
     gait_instruction_msg.type = march_shared_resources::GaitInstruction::GAIT;
     gait_instruction_msg.gait_name = name.c_str();
     gait_instruction_publisher.publish(&gait_instruction_msg);
@@ -105,6 +106,7 @@ void sendGaitMessage(const std::string& name)
 void sendIncrementStepSizeMessage()
 {
   is_transitioning = true;
+  gait_instruction_msg.header.stamp = nh.now();
   gait_instruction_msg.type = march_shared_resources::GaitInstruction::INCREMENT_STEP_SIZE;
   gait_instruction_msg.gait_name = "";
   gait_instruction_publisher.publish(&gait_instruction_msg);
@@ -113,6 +115,7 @@ void sendIncrementStepSizeMessage()
 void sendDecrementStepSizeMessage()
 {
   is_transitioning = true;
+  gait_instruction_msg.header.stamp = nh.now();
   gait_instruction_msg.type = march_shared_resources::GaitInstruction::DECREMENT_STEP_SIZE;
   gait_instruction_msg.gait_name = "";
   gait_instruction_publisher.publish(&gait_instruction_msg);
@@ -121,6 +124,7 @@ void sendDecrementStepSizeMessage()
 void sendStopMessage()
 {
   is_transitioning = false;
+  gait_instruction_msg.header.stamp = nh.now();
   gait_instruction_msg.type = march_shared_resources::GaitInstruction::STOP;
   gait_instruction_msg.gait_name = "";
   gait_instruction_publisher.publish(&gait_instruction_msg);


### PR DESCRIPTION
## Description
Small bug discovered by @RutgerVanBeek, which did not add timestamps to the gait instruction messages.

## Changes
* Added timestamps to messages
