### PR TITLE
Feature: shorter selection

### DIFF
--- a/include/state_machine.h
+++ b/include/state_machine.h
@@ -47,6 +47,12 @@ private:
                          const SectorAddress addr_activated, const std::string& gait_name,
                          const State* result = nullptr);
 
+  /**
+   * Creates a gait state where activation directly goes to selected again, so shorter.
+   */
+  State& createGaitStateToSelect(const SectorAddress addr, const SectorAddress addr_selected,
+                         const SectorAddress addr_activated, const std::string& gait_name);
+
   State& createEscapeState(const SectorAddress address, const std::string& gait_name = "");
 
   State& createEscapeGaitState(const SectorAddress addr, const SectorAddress addr_selected,

--- a/include/state_machine.h
+++ b/include/state_machine.h
@@ -51,7 +51,7 @@ private:
    * Creates a gait state where activation directly goes to selected again, so shorter.
    */
   State& createGaitStateToSelect(const SectorAddress addr, const SectorAddress addr_selected,
-                         const SectorAddress addr_activated, const std::string& gait_name);
+                                 const SectorAddress addr_activated, const std::string& gait_name);
 
   State& createEscapeState(const SectorAddress address, const std::string& gait_name = "");
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,7 @@ default_envs = debug
 [env]
 ; If Platformio gives a upload error, please specify this for your respective COM port
 upload_speed = 230400
-
+upload_port = /dev/ttyUSB0
 monitor_speed = 57600
 monitor_flags =
     --encoding

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,8 +24,8 @@ const uint8_t RE_A = 23;
 const uint8_t RE_B = 12;
 const uint8_t RE_PUSH = 19;
 const uint8_t PUSH = 18;
-//const uint8_t ROCKER_UP = 2;
-//const uint8_t ROCKER_DOWN = 5;
+const uint8_t ROCKER_UP = 2;
+const uint8_t ROCKER_DOWN = 5;
 const uint8_t UART_TX = 32;  // Software serial
 const uint8_t UART_RX = 34;  // Software serial
 const uint8_t RST = 13;      // Reset
@@ -197,7 +197,7 @@ void setup()
 void loop()
 {
   // Get button states
-//  RockerSwitchState rocker_switch_state = rocker.getState();
+  RockerSwitchState rocker_switch_state = rocker.getState();
   RotaryEncoder::Direction rotary_encoder_direction = rotaryEncoder.getDirection();
   ButtonState trigger_state = trigger.getState();
   ButtonState push_button_state = push.getState();
@@ -227,14 +227,14 @@ void loop()
     {
       sendStopMessage();
     }
-//    else if (rocker_switch_state == RockerSwitchState::UP)
-//    {
-//      sendIncrementStepSizeMessage();
-//    }
-//    else if (rocker_switch_state == RockerSwitchState::DOWN)
-//    {
-//      sendDecrementStepSizeMessage();
-//    }
+    else if (rocker_switch_state == RockerSwitchState::UP)
+    {
+      sendIncrementStepSizeMessage();
+    }
+    else if (rocker_switch_state == RockerSwitchState::DOWN)
+    {
+      sendDecrementStepSizeMessage();
+    }
   }
   else
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,8 +24,8 @@ const uint8_t RE_A = 23;
 const uint8_t RE_B = 12;
 const uint8_t RE_PUSH = 19;
 const uint8_t PUSH = 18;
-const uint8_t ROCKER_UP = 2;
-const uint8_t ROCKER_DOWN = 5;
+//const uint8_t ROCKER_UP = 2;
+//const uint8_t ROCKER_DOWN = 5;
 const uint8_t UART_TX = 32;  // Software serial
 const uint8_t UART_RX = 34;  // Software serial
 const uint8_t RST = 13;      // Reset
@@ -197,7 +197,7 @@ void setup()
 void loop()
 {
   // Get button states
-  RockerSwitchState rocker_switch_state = rocker.getState();
+//  RockerSwitchState rocker_switch_state = rocker.getState();
   RotaryEncoder::Direction rotary_encoder_direction = rotaryEncoder.getDirection();
   ButtonState trigger_state = trigger.getState();
   ButtonState push_button_state = push.getState();
@@ -227,14 +227,14 @@ void loop()
     {
       sendStopMessage();
     }
-    else if (rocker_switch_state == RockerSwitchState::UP)
-    {
-      sendIncrementStepSizeMessage();
-    }
-    else if (rocker_switch_state == RockerSwitchState::DOWN)
-    {
-      sendDecrementStepSizeMessage();
-    }
+//    else if (rocker_switch_state == RockerSwitchState::UP)
+//    {
+//      sendIncrementStepSizeMessage();
+//    }
+//    else if (rocker_switch_state == RockerSwitchState::DOWN)
+//    {
+//      sendDecrementStepSizeMessage();
+//    }
   }
   else
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ Button trigger(pins::TRIGGER);
 DoubleClickButton push(pins::PUSH);
 RotaryEncoder rotaryEncoder(pins::RE_A, pins::RE_B);
 DoubleClickButton rotaryEncoderPush(pins::RE_PUSH);
-//RockerSwitch rocker(pins::ROCKER_UP, pins::ROCKER_DOWN);
+RockerSwitch rocker(pins::ROCKER_UP, pins::ROCKER_DOWN);
 
 SoftwareSerial screen_serial(pins::UART_RX, pins::UART_TX);
 Goldelox_Serial_4DLib screen_goldelox(&screen_serial);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ Button trigger(pins::TRIGGER);
 DoubleClickButton push(pins::PUSH);
 RotaryEncoder rotaryEncoder(pins::RE_A, pins::RE_B);
 DoubleClickButton rotaryEncoderPush(pins::RE_PUSH);
-RockerSwitch rocker(pins::ROCKER_UP, pins::ROCKER_DOWN);
+//RockerSwitch rocker(pins::ROCKER_UP, pins::ROCKER_DOWN);
 
 SoftwareSerial screen_serial(pins::UART_RX, pins::UART_TX);
 Goldelox_Serial_4DLib screen_goldelox(&screen_serial);

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -136,25 +136,25 @@ void StateMachine::constructRoughTerrainMenu(State* from, State* next_obstacle)
   State& high_step4_rt = this->createGaitState(HIGHSTEP_RT_second, HIGHSTEP_RT_SELECTED, HIGHSTEP_RT_ACTIVATED,
                                                "gait_rough_terrain_high_step", &walk_in_between);
   State& small_step4_rt = this->createGaitState(SMALLSTEP_RT_second, SMALLSTEP_RT_SELECTED, SMALLSTEP_RT_ACTIVATED,
-                                                "gait_single_step_small", &high_step4_rt);
+                                                "gait_single_step_small", high_step4_rt.select());
   State& high_step3_rt = this->createGaitState(HIGHSTEP_RT_second, HIGHSTEP_RT_SELECTED, HIGHSTEP_RT_ACTIVATED,
-                                               "gait_rough_terrain_high_step", &small_step4_rt);
+                                               "gait_rough_terrain_high_step", small_step4_rt.select());
   State& small_step3_rt = this->createGaitState(SMALLSTEP_RT_second, SMALLSTEP_RT_SELECTED, SMALLSTEP_RT_ACTIVATED,
-                                                "gait_single_step_small", &high_step3_rt);
+                                                "gait_single_step_small", high_step3_rt.select());
   State& middle_step3_rt = this->createGaitState(MIDDLESTEP3_RT, MIDDLESTEP3_RT_SELECTED, MIDDLESTEP3_RT_ACTIVATED,
-                                                 "gait_rough_terrain_third_middle_step", &small_step3_rt);
+                                                 "gait_rough_terrain_third_middle_step", small_step3_rt.select());
   State& middle_step2_rt = this->createGaitState(MIDDLESTEP2_RT, MIDDLESTEP2_RT_SELECTED, MIDDLESTEP2_RT_ACTIVATED,
-                                                 "gait_rough_terrain_second_middle_step", &middle_step3_rt);
+                                                 "gait_rough_terrain_second_middle_step", middle_step3_rt.select());
   State& middle_step1_rt = this->createGaitState(MIDDLESTEP1_RT, MIDDLESTEP1_RT_SELECTED, MIDDLESTEP1_RT_ACTIVATED,
-                                                 "gait_rough_terrain_first_middle_step", &middle_step2_rt);
+                                                 "gait_rough_terrain_first_middle_step", middle_step2_rt.select());
   State& small_step2_rt = this->createGaitState(SMALLSTEP_RT, SMALLSTEP_RT_SELECTED, SMALLSTEP_RT_ACTIVATED,
-                                                "gait_single_step_small", &middle_step1_rt);
+                                                "gait_single_step_small", middle_step1_rt.select());
   State& high_step2_rt = this->createGaitState(HIGHSTEP_RT, HIGHSTEP_RT_SELECTED, HIGHSTEP_RT_ACTIVATED,
-                                               "gait_rough_terrain_high_step", &small_step2_rt);
+                                               "gait_rough_terrain_high_step", small_step2_rt.select());
   State& small_step1_rt = this->createGaitState(SMALLSTEP_RT, SMALLSTEP_RT_SELECTED, SMALLSTEP_RT_ACTIVATED,
-                                                "gait_single_step_small", &high_step2_rt);
+                                                "gait_single_step_small", high_step2_rt.select());
   State& high_step1_rt = this->createGaitState(HIGHSTEP_RT, HIGHSTEP_RT_SELECTED, HIGHSTEP_RT_ACTIVATED,
-                                               "gait_rough_terrain_high_step", &small_step1_rt);
+                                               "gait_rough_terrain_high_step", small_step1_rt.select());
 
   high_step1_rt.backTo(from).withRight(&small_step1_rt);
   small_step1_rt.backTo(from).withRight(&high_step2_rt);

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -178,8 +178,8 @@ void StateMachine::constructStairsMenu(State* from, State* next_obstacle)
       this->createGaitState(WALK_PLAIN, WALK_2O_SELECTED, WALK_2O_ACTIVATED, "gait_walk", next_obstacle);
 
   State& stairs_down = this->createState(STAIRS_DOWN);
-  State& stairs_down_step = this->createGaitState(STEP_STAIRS_DOWN, STEP_STAIRS_DOWN_SELECTED,
-                                                  STEP_STAIRS_DOWN_ACTIVATED, "gait_stairs_down_single_step", nullptr);
+  State& stairs_down_step = this->createGaitStateToSelect(STEP_STAIRS_DOWN, STEP_STAIRS_DOWN_SELECTED,
+                                                          STEP_STAIRS_DOWN_ACTIVATED, "gait_stairs_down_single_step");
   State& stairs_down_walk = this->createGaitState(WALK_STAIRS_DOWN, WALK_STAIRS_DOWN_SELECTED,
                                                   WALK_STAIRS_DOWN_ACTIVATED, "gait_stairs_down", &walk_in_between);
 
@@ -192,8 +192,8 @@ void StateMachine::constructStairsMenu(State* from, State* next_obstacle)
       this->createGaitState(WALK_STAIRS, WALK_STAIRS_SELECTED, WALK_STAIRS_ACTIVATED, "gait_walk", &stairs_down);
 
   State& stairs_up = this->createState(STAIRS_UP);
-  State& stairs_up_step = this->createGaitState(STEP_STAIRS_UP, STEP_STAIRS_UP_SELECTED, STEP_STAIRS_UP_ACTIVATED,
-                                                "gait_stairs_up_single_step");
+  State& stairs_up_step = this->createGaitStateToSelect(STEP_STAIRS_UP, STEP_STAIRS_UP_SELECTED, STEP_STAIRS_UP_ACTIVATED,
+                                                        "gait_stairs_up_single_step");
   State& stairs_up_walk = this->createGaitState(WALK_STAIRS_UP, WALK_STAIRS_UP_SELECTED, WALK_STAIRS_UP_ACTIVATED,
                                                 "gait_stairs_up", &stairs_platform);
 
@@ -225,18 +225,18 @@ void StateMachine::constructTiltedPathMenu(State* from, State* next_obstacle)
 
   State& tilted_pathL_down = this->createGaitState(LEFT_LASTSTEP_TP, LEFT_LAST_TP_SELECTED, LEFT_LAST_TP_ACTIVATED,
                                                    "gait_tilted_path_left_straight_end", &walk_in_between);
-  State& tilted_pathL_steps = this->createGaitState(LEFT_STEP_TP, LEFT_STEP_TP_SELECTED, LEFT_STEP_TP_ACTIVATED,
-                                                    "gait_tilted_path_left_single_step", nullptr);
+  State& tilted_pathL_steps = this->createGaitStateToSelect(LEFT_STEP_TP, LEFT_STEP_TP_SELECTED, LEFT_STEP_TP_ACTIVATED,
+                                                            "gait_tilted_path_left_single_step");
 
   State& tilted_pathL_up = this->createGaitState(LEFT_STEPUP_TP, LEFT_UP_TP_SELECTED, LEFT_UP_TP_ACTIVATED,
-                                                 "gait_tilted_path_left_straight_start", &tilted_pathL_steps);
+                                                 "gait_tilted_path_left_straight_start", tilted_pathL_steps.select());
 
   State& tilted_pathR_down = this->createGaitState(RIGHT_LASTSTEP_TP, RIGHT_LAST_TP_SELECTED, RIGHT_LAST_TP_ACTIVATED,
                                                    "gait_tilted_path_right_straight_end", &walk_in_between);
-  State& tilted_pathR_steps = this->createGaitState(RIGHT_STEP_TP, RIGHT_STEP_TP_SELECTED, RIGHT_STEP_TP_ACTIVATED,
-                                                    "gait_tilted_path_right_single_step", nullptr);
+  State& tilted_pathR_steps = this->createGaitStateToSelect(RIGHT_STEP_TP, RIGHT_STEP_TP_SELECTED, RIGHT_STEP_TP_ACTIVATED,
+                                                            "gait_tilted_path_right_single_step");
   State& tilted_pathR_up = this->createGaitState(RIGHT_STEPUP_TP, RIGHT_UP_TP_SELECTED, RIGHT_UP_TP_ACTIVATED,
-                                                 "gait_tilted_path_right_straight_start", &tilted_pathR_steps);
+                                                 "gait_tilted_path_right_straight_start", tilted_pathR_steps.select());
 
   tilted_pathL.withSelect(&tilted_pathL_up).backTo(from).withRight(&tilted_pathR);
   tilted_pathR.withSelect(&tilted_pathR_up).backTo(from);
@@ -261,7 +261,7 @@ void StateMachine::constructSlopeMenu(State* from, State* next_obstacle)
   State& slope_last_step = this->createGaitState(SLOPE_LAST_STEP, SLOPE_LAST_STEP_SELECTED, SLOPE_LAST_STEP_ACTIVATED,
                                                  "gait_ramp_door_last_step", &walk_in_between);
   State& slope_down = this->createGaitState(SLOPE_DOWN, SLOPE_DOWN_SELECTED, SLOPE_DOWN_ACTIVATED,
-                                            "gait_ramp_door_slope_down_fixed", &slope_last_step);
+                                            "gait_ramp_door_slope_down_fixed", slope_last_step.select());
   State& slope_walk =
       this->createGaitState(WALK_SLOPE, WALK_SLOPE_SELECTED, WALK_SLOPE_ACTIVATED, "gait_walk", &slope_down);
   State& slope_up =
@@ -389,6 +389,20 @@ State& StateMachine::createGaitState(const SectorAddress addr, const SectorAddre
   normal.withSelect(&selected);
   selected.withActivate(&activated);
   activated.withActivate(result == nullptr ? &normal : result);
+
+  return normal;
+}
+
+State& StateMachine::createGaitStateToSelect(const SectorAddress addr, const SectorAddress addr_selected,
+                                             const SectorAddress addr_activated, const std::string& gait_name)
+{
+  State& normal = this->createState(addr);
+  State& selected = this->createState(addr_selected);
+  State& activated = this->createState(addr_activated, gait_name);
+
+  normal.withSelect(&selected);
+  selected.withActivate(&activated);
+  activated.withActivate(&selected);
 
   return normal;
 }

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -109,7 +109,7 @@ void StateMachine::constructSofaMenu(State* from, State* next_obstacle)
   State& sofa_standup = this->createGaitState(SOFA_STANDUP, SOFA_STANDUP_SELECTED, SOFA_STANDUP_ACTIVATED,
                                               "gait_sofa_stand", &walk_in_between);
   State& sofa_sit =
-      this->createGaitState(SOFA_SIT, SOFA_SIT_SELECTED, SOFA_SIT_ACTIVATED, "gait_sofa_sit", &sofa_standup);
+      this->createGaitState(SOFA_SIT, SOFA_SIT_SELECTED, SOFA_SIT_ACTIVATED, "gait_sofa_sit", sofa_standup.select());
 
   sofa_sit.backTo(from).withRight(&sofa_standup);
   sofa_standup.backTo(from);

--- a/src/state_machine.cpp
+++ b/src/state_machine.cpp
@@ -192,8 +192,8 @@ void StateMachine::constructStairsMenu(State* from, State* next_obstacle)
       this->createGaitState(WALK_STAIRS, WALK_STAIRS_SELECTED, WALK_STAIRS_ACTIVATED, "gait_walk", &stairs_down);
 
   State& stairs_up = this->createState(STAIRS_UP);
-  State& stairs_up_step = this->createGaitStateToSelect(STEP_STAIRS_UP, STEP_STAIRS_UP_SELECTED, STEP_STAIRS_UP_ACTIVATED,
-                                                        "gait_stairs_up_single_step");
+  State& stairs_up_step = this->createGaitStateToSelect(STEP_STAIRS_UP, STEP_STAIRS_UP_SELECTED,
+                                                        STEP_STAIRS_UP_ACTIVATED, "gait_stairs_up_single_step");
   State& stairs_up_walk = this->createGaitState(WALK_STAIRS_UP, WALK_STAIRS_UP_SELECTED, WALK_STAIRS_UP_ACTIVATED,
                                                 "gait_stairs_up", &stairs_platform);
 
@@ -233,8 +233,8 @@ void StateMachine::constructTiltedPathMenu(State* from, State* next_obstacle)
 
   State& tilted_pathR_down = this->createGaitState(RIGHT_LASTSTEP_TP, RIGHT_LAST_TP_SELECTED, RIGHT_LAST_TP_ACTIVATED,
                                                    "gait_tilted_path_right_straight_end", &walk_in_between);
-  State& tilted_pathR_steps = this->createGaitStateToSelect(RIGHT_STEP_TP, RIGHT_STEP_TP_SELECTED, RIGHT_STEP_TP_ACTIVATED,
-                                                            "gait_tilted_path_right_single_step");
+  State& tilted_pathR_steps = this->createGaitStateToSelect(
+      RIGHT_STEP_TP, RIGHT_STEP_TP_SELECTED, RIGHT_STEP_TP_ACTIVATED, "gait_tilted_path_right_single_step");
   State& tilted_pathR_up = this->createGaitState(RIGHT_STEPUP_TP, RIGHT_UP_TP_SELECTED, RIGHT_UP_TP_ACTIVATED,
                                                  "gait_tilted_path_right_straight_start", tilted_pathR_steps.select());
 


### PR DESCRIPTION
## Description
This PR adds various shortcuts on single steps, that causes them to be selected immediately after execution. This reduces one click per gait execution.

## Changes
* After the TP up gait the TP step will be selected and can be immediately actived and after that again etc.
* Stairs up and down step are automatically selected after one step
* After slope down the final step from the slope is selected
* Immediately select sofa stand after sofa sit
* All steps in rough terrain are immediately selected after one has finished
